### PR TITLE
add tilelive-postgis

### DIFF
--- a/index.json
+++ b/index.json
@@ -33,5 +33,6 @@
   "tilelive-vector",
   "@mapbox/tilelive-vector",
   "tilejson",
-  "tilelive-xray"
+  "tilelive-xray",
+  "tilelive-postgis"
 ]


### PR DESCRIPTION
Add tilelive-postgis — a tilelive source for outputting PBF-encoded tiles from PostGIS.